### PR TITLE
Wait for cluster an extra time

### DIFF
--- a/app/playbooks/create.d/cluster/create.yml
+++ b/app/playbooks/create.d/cluster/create.yml
@@ -125,6 +125,8 @@
             chdir: /data/openshift-installer
           changed_when: no
           register: cluster_install
+          retries: 2
+          delay: 1
 
         - name: save cluster install output
           set_stats:


### PR DESCRIPTION
By waiting an extra time, we're extending the timeout period for cluster installation from 40 minutes to 80 minutes after bootstrap completion.

Fixes #113 