### PR TITLE
Added ncurses for tput

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY version.txt /version.txt
 COPY requirements.txt /deps/python_requirements.txt
 COPY requirements.yml /deps/ansible_requirements.yml
 RUN microdnf update; \
-    microdnf install python3 jq openssh-clients tar sshpass findutils telnet less; \
+    microdnf install python3 jq openssh-clients tar sshpass findutils telnet less ncurses; \
     pip3 install --user -r /deps/python_requirements.txt; \
     ansible-galaxy collection install -r /deps/ansible_requirements.yml; \
     microdnf clean all; \


### PR DESCRIPTION
Adding ncurses to Dockerfile provides `tput` binary, as needed by some [install-plan scripts](https://github.com/project-faros/cluster-manager/blob/bc2cebc51d5adc9183fdab87163e9eea59597aee/app/playbooks/install-plan.d/nvidia-support/main.sh#L7) while not introducing significant bloat to the image.

Fixes #114 