### PR TITLE
Add FIPS mode support to Faros

### DIFF
--- a/app/inventory.py
+++ b/app/inventory.py
@@ -210,6 +210,7 @@ def main(config, ipam, inv):
         extra_nodes=extra_nodes,
         ignored_macs=config['IGNORE_MACS'],
         dns_forwarders=[item['server'] for item in json.loads(config.get('DNS_FORWARDERS', '[]'))],
+        fips_mode=config['FIPS_MODE'],
         proxy=config['PROXY']=="True",
         proxy_http=config.get('PROXY_HTTP', ''),
         proxy_https=config.get('PROXY_HTTPS', ''),

--- a/app/playbooks/config.d/cluster/config.py
+++ b/app/playbooks/config.d/cluster/config.py
@@ -25,7 +25,8 @@ class ClusterConfigurator(Configurator):
             ])
         self.cluster = ParameterCollection('cluster', 'Cluster Configuration', [
             PasswordParameter('ADMIN_PASSWORD', 'Adminstrator Password'),
-            PasswordParameter('PULL_SECRET', 'Pull Secret')
+            PasswordParameter('PULL_SECRET', 'Pull Secret'),
+            Parameter('FIPS_MODE', 'Fips Mode')
             ])
         self.architecture = ParameterCollection('architecture', 'Host Record Configuration', [
             StaticParameter('MGMT_PROVIDER', 'Machine Management Provider', 'ilo'),

--- a/app/playbooks/create.d/install-repos/create.yml
+++ b/app/playbooks/create.d/install-repos/create.yml
@@ -14,6 +14,7 @@
       openshift_installer_base_domain: '{{ cluster_domain }}'
       openshift_installer_control_plane: '{{ groups.control_plane }}'
       openshift_installer_ssh_key: '{{ lookup("file", ansible_ssh_private_key_file + ".pub") }}'
+      openshift_installer_fips_mode: "{{ fips_mode }}"
       openshift_installer_pull_secret: '{{ pull_secret | to_json }}'
       openshift_installer_version: "{{ lookup('ini', 'installer section=cluster file=/app/versions.ini') }}"
       openshift_installer_proxy: "{{ proxy }}"

--- a/app/roles/openshift-installer/defaults/main.yml
+++ b/app/roles/openshift-installer/defaults/main.yml
@@ -6,6 +6,7 @@ openshift_installer_control_plane: []
 openshift_installer_cluster_id: ocp
 openshift_installer_cluster_cidr: 10.128.0.0/14
 openshift_installer_service_cidr: 172.30.0.0/16
+openshift_installer_fips_mode: False
 openshift_installer_pull_secret: {}
 openshift_installer_ssh_key: ''
 openshift_installer_proxy: False

--- a/app/roles/openshift-installer/templates/install-config.yaml.j2
+++ b/app/roles/openshift-installer/templates/install-config.yaml.j2
@@ -26,5 +26,6 @@ networking:
   - "{{ openshift_installer_service_cidr }}"
 platform:
     none: {}
+fips: "{{ openshift_installer_fips_mode }}"
 pullSecret: '{{ openshift_installer_pull_secret }}'
 sshKey: "{{ openshift_installer_ssh_key }}"

--- a/data.skel/config.sh
+++ b/data.skel/config.sh
@@ -5,6 +5,7 @@ export SUBNET_MASK=24
 export ALLOWED_SERVICES='["SSH to Bastion"]'
 # CLUSTER CONFIGURATION
 export ADMIN_PASSWORD='admin'
+export FIPS_MODE='False'
 export PULL_SECRET=''
 # CLUSTER HARDWARE
 export MGMT_PROVIDER='ilo'


### PR DESCRIPTION
We're adding a toggle for FIPS mode installation of OCP clusters.  I believe we got all the places necessary to add the prompt to the CLI and ensure it results in a `fips: true` or `fips: false` within the `install-config.yaml`.

Please let us know if there is something that was missed or a test we should run.  We will update the documentation after if this functionality is correct.